### PR TITLE
don't initialize adhoc connection when networking is disabled

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -233,14 +233,17 @@ u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	
 	if (netAdhocctlInited) return ERROR_NET_ADHOCCTL_ALREADY_INITIALIZED;
 	
-	if (initNetwork((SceNetAdhocctlAdhocId *)Memory::GetPointer(productAddr)) != 0) WARN_LOG(SCENET, "sceNetAdhocctlInit: Faking success");
+	if(g_Config.bEnableWlan)
+	{
+		if (initNetwork((SceNetAdhocctlAdhocId *)Memory::GetPointer(productAddr)) != 0) WARN_LOG(SCENET, "sceNetAdhocctlInit: Faking success");
 
-	if (!friendFinderRunning) {
-		friendFinderRunning = true;
-		friendFinderThread = std::thread(friendFinder);
+		if (!friendFinderRunning) {
+			friendFinderRunning = true;
+			friendFinderThread = std::thread(friendFinder);
+		}
+
+		netAdhocctlInited = true; //needed for cleanup during AdhocctlTerm even when it failed to connect to Adhoc Server (since it's being faked as success)
 	}
-
-	netAdhocctlInited = true; //needed for cleanup during AdhocctlTerm even when it failed to connect to Adhoc Server (since it's being faked as success)
 	return 0;
 }
 


### PR DESCRIPTION
If this isn't done then Linux halts PPSSPP at the start of the God Eater Demo
